### PR TITLE
Build and run using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Use a slim image to save space
+FROM debian:10.0-slim
+
+# Run apt-get as suggested by https://www.fromlatest.io/#/
+# libsndfile-dev is for modex
+# curl is for downloading libmikmod
+# the rest is for autotools and makeinfo used when building libmikmod
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libsndfile-dev curl devscripts dpatch fakeroot dh-make texinfo && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build libmikmod
+RUN curl -L -O https://github.com/sezero/mikmod/archive/libmikmod-3.3.11.1.tar.gz
+RUN tar -xzvf libmikmod-3.3.11.1.tar.gz
+WORKDIR mikmod-libmikmod-3.3.11.1/libmikmod
+COPY virtch.patch .
+RUN patch -p0 < virtch.patch && \
+    libtoolize && \
+    aclocal && \
+    autoconf && \
+    autoheader && \
+    automake --add-missing && \
+    ./configure && \
+    make && \
+    make install
+
+# Build modex
+WORKDIR /
+COPY Makefile .
+COPY modex.c .
+RUN make
+
+# The location of the libmikmod shared library file, required when running modex
+ENV LD_LIBRARY_PATH /mikmod-libmikmod-3.3.11.1/libmikmod/.libs/
+
+# Run modex when running the container
+ENTRYPOINT ["/modex"]
+

--- a/README.md
+++ b/README.md
@@ -13,3 +13,23 @@ Installation
 3. Apply virtch.patch (e.g. patch -p0 < ../virtch.patch)
 4. Build mikmod (./configure && make && make install)
 5. Build modex (make)
+
+Using Docker
+------------
+
+The tool can also be built and run in a Linux container if
+you have Docker and want to avoid installing tools locally.
+
+Build the Docker image from the modex directory:
+```
+$ docker build --tag modex .
+```
+
+Then go to a directory containing your modules and run modex:
+```
+$ cd /my/xms/
+$ docker run --rm --volume $(pwd):/host --workdir /host modex my.xm
+```
+In the above example, the input file my.xm is in the /my/xms/ directory
+on your computer and modex writes wav files to this directory.
+


### PR DESCRIPTION
Motivation:
Make it easier to use modex on any platform by building and running it
in a Linux container.

Modifications:
Added a Dockerfile based on debian which can be built and run using the
instructions added to the README. Tested on macOS.

The instructions for building mikmod were not quite up to date, at least I
needed to install autotools and makeinfo to get it working. I used help from
these sites for writing the Dockerfile:

- https://developer.gnome.org/anjuta-build-tutorial/stable/create-autotools.html.en
- https://stackoverflow.com/questions/22603163/automake-error-ltmain-sh-not-found
- https://stackoverflow.com/questions/338317/what-is-makeinfo-and-how-do-i-get-it
- https://unix.stackexchange.com/questions/22926/where-do-executables-look-for-shared-objects-at-runtime